### PR TITLE
Mark required fields as nullable

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -1081,17 +1081,21 @@ definitions:
         format: int64
       segmentID:
         type: integer
+        x-nullable: true
         format: int64
         minimum: 1
       variantID:
         type: integer
+        x-nullable: true
         format: int64
         minimum: 1
       variantKey:
         type: string
+        x-nullable: true
         minLength: 1
       variantAttachment:
         type: object
+        x-nullable: true
       evalContext:
         $ref: '#/definitions/evalContext'
       timestamp:

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -397,17 +397,21 @@ definitions:
         format: int64
       segmentID:
         type: integer
+        x-nullable: true
         format: int64
         minimum: 1
       variantID:
         type: integer
+        x-nullable: true
         format: int64
         minimum: 1
       variantKey:
         type: string
+        x-nullable: true
         minLength: 1
       variantAttachment:
         type: object
+        x-nullable: true
       evalContext:
         $ref: "#/definitions/evalContext"
       timestamp:

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1334,23 +1334,27 @@ func init() {
         "segmentID": {
           "type": "integer",
           "format": "int64",
-          "minimum": 1
+          "minimum": 1,
+          "x-nullable": true
         },
         "timestamp": {
           "type": "string",
           "minLength": 1
         },
         "variantAttachment": {
-          "type": "object"
+          "type": "object",
+          "x-nullable": true
         },
         "variantID": {
           "type": "integer",
           "format": "int64",
-          "minimum": 1
+          "minimum": 1,
+          "x-nullable": true
         },
         "variantKey": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         }
       }
     },
@@ -3017,23 +3021,27 @@ func init() {
         "segmentID": {
           "type": "integer",
           "format": "int64",
-          "minimum": 1
+          "minimum": 1,
+          "x-nullable": true
         },
         "timestamp": {
           "type": "string",
           "minLength": 1
         },
         "variantAttachment": {
-          "type": "object"
+          "type": "object",
+          "x-nullable": true
         },
         "variantID": {
           "type": "integer",
           "format": "int64",
-          "minimum": 1
+          "minimum": 1,
+          "x-nullable": true
         },
         "variantKey": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "x-nullable": true
         }
       }
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Certain fields are marked required, and "nil" is explicitly passed in when constructing the model. We should mark these as nullable.

## Description
<!--- Describe your changes in detail -->
Simply mark the fields as nullable in the swagger spec.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When the fields aren't marked as nullable, the autogenerated Scala client doesn't expect null and can't deserialize the response correctly into an Option type. This should hopefully fix that problem.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the server locally and verified everything works correctly. Will regenerate the scala client and test as well. This change should be backwards compatible because the previous version was already using/expecting nil values.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)