### PR TITLE
Make query batch use post with body instead of array query params

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -733,19 +733,21 @@ paths:
           schema:
             $ref: '#/definitions/error'
   /query/batch:
-    get:
+    post:
       tags:
         - query
       operationId: getFlagByNameBatch
       parameters:
-        - in: query
-          name: flagNames
+        - in: body
+          name: body
           required: true
-          type: array
-          items:
-            type: string
-            minLength: 1
-          minItems: 1
+          description: query batch request
+          schema:
+            type: array
+            items:
+              type: string
+              minLength: 1
+            minItems: 1
       responses:
         '200':
           description: >-

--- a/pkg/handler/query.go
+++ b/pkg/handler/query.go
@@ -42,7 +42,7 @@ func (qAPI *queryAPI) GetFlagByName(params query.GetFlagByNameParams) middleware
 }
 
 func (qAPI *queryAPI) GetFlagByNameBatch(params query.GetFlagByNameBatchParams) middleware.Responder {
-	flagNames := params.FlagNames
+	flagNames := params.Body
 
 	fs := []entity.Flag{}
 	q := entity.NewFlagQuerySet(getDB())

--- a/swagger/query_batch.yaml
+++ b/swagger/query_batch.yaml
@@ -1,16 +1,18 @@
-get:
+post:
   tags:
     - query
   operationId: getFlagByNameBatch
   parameters:
-    - in: query
-      name: flagNames
+    - in: body
+      name: body
       required: true
-      type: array
-      items:
-        type: string
-        minLength: 1
-      minItems: 1
+      description: query batch request
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+        minItems: 1
   responses:
     200:
       description: returns list of flags with the given names. Omits flags who's names weren't found.

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1061,22 +1061,25 @@ func init() {
       }
     },
     "/query/batch": {
-      "get": {
+      "post": {
         "tags": [
           "query"
         ],
         "operationId": "getFlagByNameBatch",
         "parameters": [
           {
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "name": "flagNames",
-            "in": "query",
-            "required": true
+            "description": "query batch request",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
           }
         ],
         "responses": {
@@ -2748,22 +2751,25 @@ func init() {
       }
     },
     "/query/batch": {
-      "get": {
+      "post": {
         "tags": [
           "query"
         ],
         "operationId": "getFlagByNameBatch",
         "parameters": [
           {
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "name": "flagNames",
-            "in": "query",
-            "required": true
+            "description": "query batch request",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
           }
         ],
         "responses": {

--- a/swagger_gen/restapi/operations/flagr_api.go
+++ b/swagger_gen/restapi/operations/flagr_api.go
@@ -546,10 +546,10 @@ func (o *FlagrAPI) initHandlerCache() {
 	}
 	o.handlers["GET"]["/query"] = query.NewGetFlagByName(o.context, o.QueryGetFlagByNameHandler)
 
-	if o.handlers["GET"] == nil {
-		o.handlers["GET"] = make(map[string]http.Handler)
+	if o.handlers["POST"] == nil {
+		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/query/batch"] = query.NewGetFlagByNameBatch(o.context, o.QueryGetFlagByNameBatchHandler)
+	o.handlers["POST"]["/query/batch"] = query.NewGetFlagByNameBatch(o.context, o.QueryGetFlagByNameBatchHandler)
 
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)

--- a/swagger_gen/restapi/operations/query/get_flag_by_name_batch.go
+++ b/swagger_gen/restapi/operations/query/get_flag_by_name_batch.go
@@ -29,7 +29,7 @@ func NewGetFlagByNameBatch(ctx *middleware.Context, handler GetFlagByNameBatchHa
 	return &GetFlagByNameBatch{Context: ctx, Handler: handler}
 }
 
-/*GetFlagByNameBatch swagger:route GET /query/batch query getFlagByNameBatch
+/*GetFlagByNameBatch swagger:route POST /query/batch query getFlagByNameBatch
 
 GetFlagByNameBatch get flag by name batch API
 

--- a/swagger_gen/restapi/operations/query/get_flag_by_name_batch_urlbuilder.go
+++ b/swagger_gen/restapi/operations/query/get_flag_by_name_batch_urlbuilder.go
@@ -9,17 +9,11 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
-
-	"github.com/go-openapi/swag"
 )
 
 // GetFlagByNameBatchURL generates an URL for the get flag by name batch operation
 type GetFlagByNameBatchURL struct {
-	FlagNames []string
-
 	_basePath string
-	// avoid unkeyed usage
-	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -48,27 +42,6 @@ func (o *GetFlagByNameBatchURL) Build() (*url.URL, error) {
 		_basePath = "/api/v1"
 	}
 	result.Path = golangswaggerpaths.Join(_basePath, _path)
-
-	qs := make(url.Values)
-
-	var flagNamesIR []string
-	for _, flagNamesI := range o.FlagNames {
-		flagNamesIS := flagNamesI
-		if flagNamesIS != "" {
-			flagNamesIR = append(flagNamesIR, flagNamesIS)
-		}
-	}
-
-	flagNames := swag.JoinByFormat(flagNamesIR, "")
-
-	if len(flagNames) > 0 {
-		qsv := flagNames[0]
-		if qsv != "" {
-			qs.Set("flagNames", qsv)
-		}
-	}
-
-	result.RawQuery = qs.Encode()
 
 	return &result, nil
 }


### PR DESCRIPTION
While working with the Scala client code, I discovered another bug... the client code doesn't convert array query params correctly. It simply calls the `toString` method on the argument, which improperly encodes it as `?flagNames=List(a,b,c)`.

So instead, let's use a POST request and put the flagNames in the body for batch query. Batch evaluation also uses a post with body.