### PR TITLE
Create standalone docker container for sync'ing flags from a YAML file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.out
 *~
 flagr
+flagr-sync
 flagr.sqlite
 !*/
 site/

--- a/Dockerfile-sync
+++ b/Dockerfile-sync
@@ -1,0 +1,11 @@
+FROM checkr/flagr-ci as builder
+WORKDIR /go/src/github.com/checkr/flagr
+ADD . .
+RUN make build-sync
+
+FROM alpine:3.6
+RUN apk add --no-cache libc6-compat ca-certificates
+WORKDIR /go/src/github.com/checkr/flagr
+VOLUME ["/data"]
+COPY --from=builder /go/src/github.com/checkr/flagr/flagr-sync ./flagr-sync
+CMD ./flagr-sync

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,20 @@ serve_docs:
 	@docsify serve $(PWD)/docs
 
 ################################
+### Flagr sync related
+################################
+
+build-sync:
+	@echo "Building flagr-sync to $(PWD)/flagr-sync ..."
+	@CGO_ENABLED=1 go build -o $(PWD)/flagr-sync github.com/checkr/flagr/pkg/setup/cmd
+
+run-sync:
+	@$(PWD)/flagr-sync
+
+docker-sync:
+	docker build -t flagr-sync -f $(PWD)/Dockerfile-sync .
+
+################################
 ### Private
 ################################
 

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -90,4 +90,8 @@ var Config = struct {
 	JWTAuthSecret             string `env:"FLAGR_JWT_AUTH_SECRET" envDefault:""`
 	JWTAuthNoTokenRedirectURL string `env:"FLAGR_JWT_AUTH_NO_TOKEN_REDIRECT_URL" envDefault:""`
 	JWTAuthUserProperty       string `env:"FLAGR_JWT_AUTH_USER_PROPERTY" envDefault:"flagr_user"`
+
+	// YAMLConfigFilePath is the filepath to a YAML file for loading flag
+	// configuration. If empty, no flags will be loaded
+	YAMLConfigFilePath		  string `env:"FLAGR_YAML_CONFIG_FILE" envDefault:""`
 }{}

--- a/pkg/setup/api.go
+++ b/pkg/setup/api.go
@@ -1,0 +1,152 @@
+package setup
+
+import (
+    "github.com/checkr/flagr/pkg/entity"
+
+    "github.com/jinzhu/gorm"
+    "github.com/sirupsen/logrus"
+
+)
+
+// Helper for making DB calls, and logging fatal if an error was found
+func fatalIfDBErrors(db *gorm.DB) {
+    errs := db.GetErrors()
+    if len(errs) > 0 {
+        logrus.Fatalf("Errors while making DB call: %v", errs)
+    }
+}
+
+// SetupAPI contains helper functions for manipualting the DB when
+// synchronizing flags during setup.
+type SetupAPI struct {
+    db *gorm.DB
+}
+
+func (api *SetupAPI) SaveFlagSnapshot(flagID uint, updatedBy string) {
+    entity.SaveFlagSnapshot(api.db, flagID, updatedBy)
+}
+
+func (api *SetupAPI) DeleteUnusedFlags(flagNames []string) {
+    q := entity.NewFlagQuerySet(api.db)
+    err := q.NameNotIn(flagNames...).Delete()
+    if err != nil {
+        logrus.Fatalf("Error while deleting flags: %s", err)
+    }
+}
+
+func (api *SetupAPI) GetOrCreateFlag(flagName string) *entity.Flag {
+    flag := &entity.Flag{}
+    fatalIfDBErrors(
+        api.db.FirstOrCreate(flag, entity.Flag{Name: flagName}),
+    )
+    return flag
+}
+
+func (api *SetupAPI) UpdateFlag(flag *entity.Flag, description string, enabled bool) {
+    flag.Description = description
+    flag.Enabled = enabled
+    fatalIfDBErrors(api.db.Save(flag))
+}
+
+func (api *SetupAPI) EnsureVariantsExist(flagID uint, keys []string) []*entity.Variant {
+    result := make([]*entity.Variant, 0, len(keys))
+    for _, key := range keys {
+        variant := &entity.Variant{}
+        fatalIfDBErrors(
+            api.db.FirstOrCreate(
+                variant,
+                entity.Variant{
+                    FlagID: flagID,
+                    Key: key,
+                    Attachment: entity.Attachment{},
+                },
+            ),
+        )
+        result = append(result, variant)
+    }
+    return result
+}
+
+func (api *SetupAPI) DeleteUnusedVariants(flagID uint, keys []string) {
+    q := entity.NewVariantQuerySet(api.db)
+    err := q.FlagIDEq(flagID).KeyNotIn(keys...).Delete()
+    if err != nil {
+        logrus.Fatalf("Error while deleting variants: %s", err)
+    }
+}
+
+func (api *SetupAPI) AppendSegment(
+    flagID uint,
+    description string,
+    rollout uint,
+) *entity.Segment {
+    segment := &entity.Segment{
+        FlagID: flagID,
+        Description: description,
+        RolloutPercent: rollout,
+        Rank: entity.SegmentDefaultRank,
+    }
+    if err := segment.Create(api.db); err != nil {
+        logrus.Fatalf("Error creating segment: %s", err)
+    }
+    return segment
+}
+
+func (api *SetupAPI) DeleteLeftoverSegments(flagID uint, segment *entity.Segment) {
+    // Delete all segments that are ordered after the given one
+    q := entity.NewSegmentQuerySet(api.db)
+    if err := q.FlagIDEq(flagID).RankGt(segment.Rank).Delete(); err != nil {
+        logrus.Fatalf("Error deleting segments: %s", err)
+    }
+
+    // Also delete elements that are tied in rank but have ID gte
+    q = entity.NewSegmentQuerySet(api.db)
+    q = q.FlagIDEq(flagID).RankEq(segment.Rank).IDGte(segment.ID)
+    if err := q.Delete(); err != nil {
+        logrus.Fatalf("Error deleting segments: %s", err)
+    }
+}
+
+func (api *SetupAPI) UpdateSegment(
+    segment *entity.Segment,
+    description string,
+    rollout uint,
+) {
+    segment.Description = description
+    segment.RolloutPercent = rollout
+    fatalIfDBErrors(api.db.Save(segment))
+}
+
+func (api *SetupAPI) EnsureConstraints(
+    segmentID uint,
+    constraints []*entity.Constraint,
+) {
+    // Delete every constraint and re-create them
+    q := entity.NewConstraintQuerySet(api.db).SegmentIDEq(segmentID)
+    if err := q.Delete(); err != nil {
+        logrus.Fatalf("Failed to delete constraints: %s", err)
+    }
+
+    for _, constraint := range constraints {
+        if err := constraint.Create(api.db); err != nil {
+            logrus.Fatalf("Unable to create constraint: %s", err)
+        }
+    }
+}
+
+func (api *SetupAPI) EnsureDistributions(
+    segmentID uint,
+    distributions []*entity.Distribution,
+) {
+    // Delete every distribution and re-create them
+    q := entity.NewDistributionQuerySet(api.db).SegmentIDEq(segmentID)
+    if err := q.Delete(); err != nil {
+        logrus.Fatalf("Failed to delete distributions: %s", err)
+    }
+
+    for _, distribution := range distributions {
+        if err := distribution.Create(api.db); err != nil {
+            logrus.Fatalf("Unable to create distribution: %s", err)
+        }
+    }
+}

--- a/pkg/setup/cmd/main.go
+++ b/pkg/setup/cmd/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+     "github.com/checkr/flagr/pkg/repo"
+     "github.com/checkr/flagr/pkg/setup"
+)
+
+// Simple setup program which synchronizes flags from a YAML file to Flagr DB
+
+func main() {
+    db := repo.GetDB()
+    defer db.Close()
+
+    setup.NewFlagSynchronizer(db).SynchronizeFlags()
+
+}

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -1,0 +1,198 @@
+package setup
+
+import (
+    "io/ioutil"
+    "encoding/json"
+
+    "github.com/checkr/flagr/pkg/config"
+    "github.com/checkr/flagr/pkg/entity"
+    "github.com/checkr/flagr/pkg/repo"
+
+    "github.com/sirupsen/logrus"
+
+    yaml "gopkg.in/yaml.v2"
+)
+
+
+// FlagSynchronizer synchronizes YAML config to actual Flagr DB
+type FlagSynchronizer struct {
+    api *SetupAPI
+}
+
+func NewFlagSynchronizer() *FlagSynchronizer {
+    return &FlagSynchronizer{
+        api: &SetupAPI{db: repo.GetDB()},
+    }
+}
+
+// SynchronizeFlags synchronizes flags from the YAML file specified in env.
+func (s *FlagSynchronizer) SynchronizeFlags() {
+    // Load config from YAML file
+    yamlData, err := ioutil.ReadFile(config.Config.YAMLConfigFilePath)
+    if err != nil {
+        logrus.Fatalf("Unable to read YAML config:", err)
+    }
+    yamlConfig := &YAMLConfigFile{}
+    err = yaml.Unmarshal(yamlData, yamlConfig)
+    if err != nil {
+        logrus.Fatalf("Unable to unmarshal YAML config: %s.", err)
+    }
+
+    // Synchronize each flag
+    for flagName, yamlFlag := range yamlConfig.Flags {
+        logrus.Infof("Synchronizing flag: %s", flagName)
+        flagID := s.synchronizeFlag(flagName, yamlFlag)
+        s.api.SaveFlagSnapshot(flagID, "TODO")
+    }
+
+    // Delete flags that no longer exist
+    allFlagNames := make([]string, 0, len(yamlConfig.Flags))
+    for key, _ := range yamlConfig.Flags {
+        allFlagNames = append(allFlagNames, key)
+    }
+    s.api.DeleteUnusedFlags(allFlagNames)
+}
+
+func (s *FlagSynchronizer) synchronizeFlag(flagName string, yamlFlag *YAMLFlag) uint {
+    flag := s.api.GetOrCreateFlag(flagName)
+
+    // Update flag description and enabled state
+    s.api.UpdateFlag(flag, yamlFlag.Description, yamlFlag.Enabled)
+
+    // Create new variants that we need
+    variantKeys := make([]string, 0, len(yamlFlag.Variants))
+    for _, yamlVariant := range yamlFlag.Variants {
+        variantKeys = append(variantKeys, yamlVariant.Key)
+    }
+    variants := s.api.EnsureVariantsExist(flag.ID, variantKeys)
+    variantKeyToID := make(map[string]uint)
+    for _, variant := range variants {
+        variantKeyToID[variant.Key] = variant.ID
+    }
+
+    // Synchronize segments
+    s.synchronizeSegments(flag, yamlFlag.Segments, variantKeyToID)
+
+    // Delete un-needed variants, must do this after synchronizing segments
+    // because we can't delete a variant until it is no longer being used
+    s.api.DeleteUnusedVariants(flag.ID, variantKeys)
+
+    return flag.ID
+}
+
+func (s *FlagSynchronizer) synchronizeSegments(
+    flag *entity.Flag,
+    yamlSegments []*YAMLSegment,
+    variantKeyToID map[string]uint,
+) {
+    // Preload flag to get nested objects
+    err := flag.Preload(s.api.db)
+    if err != nil {
+        logrus.Fatalf("Error preloading flag %s: %s", flag.Name, err)
+    }
+    segments := flag.Segments
+
+    // Synchronization strategy is:
+    // While segments exist in DB, modify them to be the same as the YAML.
+    // Otherwise create a new segment that matches the YAML. Delete any
+    // remaining segments that are no longer used.
+    for i, yamlSegment := range yamlSegments {
+        var segment *entity.Segment
+        if i >= len(segments) {
+            // No more segments, create a new one
+            segment = s.api.AppendSegment(
+                flag.ID, yamlSegment.Description, yamlSegment.Rollout)
+        } else {
+            segment = &segments[i]
+            s.api.UpdateSegment(
+                segment, yamlSegment.Description, yamlSegment.Rollout)
+        }
+
+        s.synchronizeSegment(flag.ID, segment, yamlSegment, variantKeyToID)
+    }
+
+    // Delete any extra segments
+    if len(segments) > len(yamlSegments) {
+        s.api.DeleteLeftoverSegments(flag.ID, &segments[len(yamlSegments)])
+    }
+}
+
+func (s *FlagSynchronizer) synchronizeSegment(
+    flagID uint,
+    segment *entity.Segment,
+    yamlSegment *YAMLSegment,
+    variantKeyToID map[string]uint,
+) {
+    // Build constraints and sync them
+    constraints := make([]*entity.Constraint, 0, len(yamlSegment.Constraints))
+    for _, yamlConstraint := range yamlSegment.Constraints {
+        jsonBytes, err := json.Marshal(yamlConstraint.Value)
+        if err != nil {
+            logrus.Fatalf(
+                "Unable to marshal constraint value: %v", yamlConstraint.Value)
+        }
+        constraints = append(constraints, &entity.Constraint{
+            SegmentID: segment.ID,
+            Property: yamlConstraint.Property,
+            Operator: s.convertOpString(yamlConstraint.Operator),
+            Value: string(jsonBytes),
+        })
+    }
+    s.api.EnsureConstraints(segment.ID, constraints)
+
+    // Synchronize distributions
+    distributions := make(
+        []*entity.Distribution, 0, len(yamlSegment.Distributions))
+    var totalPercent uint = 0
+    for _, yamlDistribution := range yamlSegment.Distributions {
+        distributions = append(distributions, &entity.Distribution{
+            SegmentID: segment.ID,
+            VariantID: variantKeyToID[yamlDistribution.Key],
+            VariantKey: yamlDistribution.Key,
+            Percent: yamlDistribution.Percent,
+        })
+        totalPercent += yamlDistribution.Percent
+    }
+    if totalPercent != 100 {
+        logrus.Fatalf(
+            "Distribution percent does not sum to 100 for flag %s", flagID)
+    }
+    s.api.EnsureDistributions(segment.ID, distributions)
+
+}
+
+func (s *FlagSynchronizer) convertOpString(op string) string {
+    switch op {
+    case "==":
+        return "EQ"
+    case "!=":
+        return "NEQ"
+    case "<":
+        return "LT"
+    case "<=":
+        return "LTE"
+    case ">":
+        return "GT"
+    case ">=":
+        return "GTE"
+    case "=~":
+        return "EREG"
+    case "!~":
+        return "NEREG"
+    case "IN":
+        return "IN"
+    case "NOT IN":
+        return "NOT IN"
+    case "CONTAINS":
+        return "CONTAINS"
+    case "NOT CONTAINS":
+        return "NOT CONTAINS"
+    default:
+        logrus.Fatalf("Unsupported operand %s.", op)
+    }
+    return ""
+}
+
+
+
+

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -7,7 +7,7 @@ import (
     "github.com/checkr/flagr/pkg/config"
     "github.com/checkr/flagr/pkg/entity"
     "github.com/checkr/flagr/pkg/repo"
-
+    "github.com/jinzhu/gorm"
     "github.com/sirupsen/logrus"
 
     yaml "gopkg.in/yaml.v2"
@@ -19,9 +19,12 @@ type FlagSynchronizer struct {
     api *SetupAPI
 }
 
-func NewFlagSynchronizer() *FlagSynchronizer {
+func NewFlagSynchronizer(db *gorm.DB) *FlagSynchronizer {
+    if db == nil {
+        db = repo.GetDB()
+    }
     return &FlagSynchronizer{
-        api: &SetupAPI{db: repo.GetDB()},
+        api: &SetupAPI{db: db},
     }
 }
 

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -49,11 +49,11 @@ func (s *FlagSynchronizer) SynchronizeFlags() {
     }
 
     // Delete flags that no longer exist
-    allFlagNames := make([]string, 0, len(yamlConfig.Flags))
-    for key, _ := range yamlConfig.Flags {
-        allFlagNames = append(allFlagNames, key)
-    }
-    s.api.DeleteUnusedFlags(allFlagNames)
+    // allFlagNames := make([]string, 0, len(yamlConfig.Flags))
+    // for key, _ := range yamlConfig.Flags {
+    //     allFlagNames = append(allFlagNames, key)
+    // }
+    s.api.DeleteUnusedFlags(yamlConfig.Flags)
 }
 
 func (s *FlagSynchronizer) synchronizeFlag(flagName string, yamlFlag *YAMLFlag) uint {
@@ -78,7 +78,7 @@ func (s *FlagSynchronizer) synchronizeFlag(flagName string, yamlFlag *YAMLFlag) 
 
     // Delete un-needed variants, must do this after synchronizing segments
     // because we can't delete a variant until it is no longer being used
-    s.api.DeleteUnusedVariants(flag.ID, variantKeys)
+    s.api.DeleteUnusedVariants(flag.ID, variantKeyToID)
 
     return flag.ID
 }

--- a/pkg/setup/types.go
+++ b/pkg/setup/types.go
@@ -1,0 +1,41 @@
+package setup
+
+
+// Types for unmarshaling YAML config file
+
+type YAMLConfigFile struct {
+    CommonVariants interface{} `yaml:"common_variants"`
+    CommonVariantGroups interface{} `yaml:"common_variant_groups"`
+    CommonSegments interface{} `yaml:"common_segments"`
+
+    Flags map[string]*YAMLFlag
+}
+
+type YAMLFlag struct {
+    Description string
+    Enabled bool
+    Variants []*YAMLVariant
+    Segments []*YAMLSegment
+}
+
+type YAMLVariant struct {
+    Key string
+}
+
+type YAMLSegment struct {
+    Description string
+    Rollout uint
+    Constraints []*YAMLConstraint
+    Distributions []*YAMLDistribution
+}
+
+type YAMLConstraint struct {
+    Property string
+    Operator string
+    Value interface{}
+}
+
+type YAMLDistribution struct {
+    Percent uint
+    Key string
+}

--- a/swagger_gen/restapi/configure_flagr.go
+++ b/swagger_gen/restapi/configure_flagr.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/checkr/flagr/pkg/config"
 	"github.com/checkr/flagr/pkg/handler"
+	"github.com/checkr/flagr/pkg/setup"
 	"github.com/checkr/flagr/swagger_gen/restapi/operations"
 	"github.com/sirupsen/logrus"
 
@@ -46,6 +47,7 @@ func configureTLS(tlsConfig *tls.Config) {
 // This function can be called multiple times, depending on the number of serving schemes.
 // scheme value will be set accordingly: "http", "https" or "unix"
 func configureServer(s *http.Server, scheme, addr string) {
+	setup.NewFlagSynchronizer().SynchronizeFlags()
 }
 
 // The middleware configuration is for the handler executors. These do not apply to the swagger.json document.

--- a/swagger_gen/restapi/configure_flagr.go
+++ b/swagger_gen/restapi/configure_flagr.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/checkr/flagr/pkg/config"
 	"github.com/checkr/flagr/pkg/handler"
-	"github.com/checkr/flagr/pkg/setup"
 	"github.com/checkr/flagr/swagger_gen/restapi/operations"
 	"github.com/sirupsen/logrus"
 
@@ -47,7 +46,6 @@ func configureTLS(tlsConfig *tls.Config) {
 // This function can be called multiple times, depending on the number of serving schemes.
 // scheme value will be set accordingly: "http", "https" or "unix"
 func configureServer(s *http.Server, scheme, addr string) {
-	setup.NewFlagSynchronizer().SynchronizeFlags()
 }
 
 // The middleware configuration is for the handler executors. These do not apply to the swagger.json document.


### PR DESCRIPTION
This diff adds a standalone container that we can run to sync flags from a YAML file. This is useful so developers can statically declare flags. We want the standalone docker container so we can use it as part of a Kubernetes job during deployment.