### PR TITLE
Support attachments in flagr-sync

### DIFF
--- a/pkg/setup/api.go
+++ b/pkg/setup/api.go
@@ -62,17 +62,17 @@ func (api *SetupAPI) UpdateFlag(flag *entity.Flag, description string, enabled b
     fatalIfDBErrors(api.db.Save(flag))
 }
 
-func (api *SetupAPI) EnsureVariantsExist(flagID uint, keys []string) []*entity.Variant {
-    result := make([]*entity.Variant, 0, len(keys))
-    for _, key := range keys {
+func (api *SetupAPI) EnsureVariantsExist(flagID uint, variants []*YAMLVariant) []*entity.Variant {
+    result := make([]*entity.Variant, 0, len(variants))
+    for _, v := range variants {
         variant := &entity.Variant{}
         fatalIfDBErrors(
             api.db.FirstOrCreate(
                 variant,
                 entity.Variant{
                     FlagID: flagID,
-                    Key: key,
-                    Attachment: entity.Attachment{},
+                    Key: v.Key,
+                    Attachment: v.Attachment,
                 },
             ),
         )

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -63,11 +63,7 @@ func (s *FlagSynchronizer) synchronizeFlag(flagName string, yamlFlag *YAMLFlag) 
     s.api.UpdateFlag(flag, yamlFlag.Description, yamlFlag.Enabled)
 
     // Create new variants that we need
-    variantKeys := make([]string, 0, len(yamlFlag.Variants))
-    for _, yamlVariant := range yamlFlag.Variants {
-        variantKeys = append(variantKeys, yamlVariant.Key)
-    }
-    variants := s.api.EnsureVariantsExist(flag.ID, variantKeys)
+    variants := s.api.EnsureVariantsExist(flag.ID, yamlFlag.Variants)
     variantKeyToID := make(map[string]uint)
     for _, variant := range variants {
         variantKeyToID[variant.Key] = variant.ID

--- a/pkg/setup/types.go
+++ b/pkg/setup/types.go
@@ -20,6 +20,7 @@ type YAMLFlag struct {
 
 type YAMLVariant struct {
     Key string
+    Attachment map[string]string
 }
 
 type YAMLSegment struct {


### PR DESCRIPTION
flagr-sync currently does not read attachments
from the yaml file. To support reading attachments,
add the `Attachment` key to the variant data
structure and pass it down to the flagr call.